### PR TITLE
Core3 dml 1092 depth map

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -99,7 +99,7 @@
     ],
     "editor.detectIndentation": false,
     "editor.tabSize": 4,
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
     "C_Cpp.errorSquiggles": "Disabled",
     "gitmoji.additionalEmojis": [
         {

--- a/include/neural-graphics-primitives/common.h
+++ b/include/neural-graphics-primitives/common.h
@@ -67,6 +67,13 @@ enum class EMeshRenderMode : int {
 	FaceIDs,
 };
 
+enum class EGroundTruthRenderMode : int {
+	Shade,
+	Depth,
+	NumRenderModes,
+};
+static constexpr const char* GroundTruthRenderModeStr = "Shade\0Depth\0\0";
+
 enum class ERenderMode : int {
 	AO,
 	Shade,

--- a/include/neural-graphics-primitives/render_buffer.h
+++ b/include/neural-graphics-primitives/render_buffer.h
@@ -218,6 +218,17 @@ public:
 		cudaStream_t stream
 	);
 
+	void overlay_depth(
+		float alpha,
+		const float* __restrict__ depth,
+		float depth_scale,
+		const Eigen::Vector2i& resolution,
+		int fov_axis,
+		float zoom,
+		const Eigen::Vector2f& screen_center,
+		cudaStream_t stream
+	);
+
 	void overlay_false_color(Eigen::Vector2i training_resolution, bool to_srgb, int fov_axis, cudaStream_t stream, const float *error_map, Eigen::Vector2i error_map_resolution, const float *average, float brightness, bool viridis);
 
 	SurfaceProvider& surface_provider() {

--- a/include/neural-graphics-primitives/render_buffer.h
+++ b/include/neural-graphics-primitives/render_buffer.h
@@ -225,6 +225,7 @@ public:
 		const Eigen::Vector2i& resolution,
 		int fov_axis,
 		float zoom,
+		float max_depth,
 		const Eigen::Vector2f& screen_center,
 		cudaStream_t stream
 	);

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -426,6 +426,8 @@ public:
 
 	bool m_include_optimizer_state_in_snapshot = false;
 	bool m_render_ground_truth = false;
+	EGroundTruthRenderMode m_ground_truth_render_mode = EGroundTruthRenderMode::Shade;
+
 	bool m_train = false;
 	bool m_training_data_available = false;
 	bool m_render = true;

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -453,6 +453,7 @@ public:
 	Eigen::Vector2f m_relative_focal_length = Eigen::Vector2f::Ones();
 	uint32_t m_fov_axis = 1;
 	float m_zoom = 1.f; // 2d zoom factor (for insets?)
+	float m_max_depth = 8.0f; // Max depth treshold for tonemapper
 	Eigen::Vector2f m_screen_center = Eigen::Vector2f::Constant(0.5f); // center of 2d zoom
 
 	Eigen::Matrix<float, 3, 4> m_camera = Eigen::Matrix<float, 3, 4>::Zero();

--- a/runner/run.sh
+++ b/runner/run.sh
@@ -1,0 +1,12 @@
+#/bin/bash
+
+DIR=$(dirname ${0})
+ROOT_DIR="$( cd ${DIR} >/dev/null 2>&1 && pwd )"
+cd $ROOT_DIR/..
+
+scene=kitchen
+
+python3 scripts/run.py --scene data/ours/${scene}/transform.json            \
+        --mode nerf                                                         \
+        --network base.json                                                 \
+        --gui

--- a/src/nerf_loader.cu
+++ b/src/nerf_loader.cu
@@ -619,7 +619,7 @@ NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float shar
 					if (wa != dst.res.x() || ha != dst.res.y()) {
 						throw std::runtime_error{std::string{"Depth image has wrong resolution: "} + depthpath.str()};
 					}
-					//tlog::success() << "Depth loaded from " << depthpath;
+					tlog::success() << "Depth loaded from " << depthpath;
 				}
 			}
 

--- a/src/nerf_loader.cu
+++ b/src/nerf_loader.cu
@@ -619,7 +619,7 @@ NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float shar
 					if (wa != dst.res.x() || ha != dst.res.y()) {
 						throw std::runtime_error{std::string{"Depth image has wrong resolution: "} + depthpath.str()};
 					}
-					tlog::success() << "Depth loaded from " << depthpath;
+					// tlog::success() << "Depth loaded from " << depthpath;
 				}
 			}
 

--- a/src/nerf_loader.cu
+++ b/src/nerf_loader.cu
@@ -780,7 +780,7 @@ void NerfDataset::set_training_image(int frame_idx, const Eigen::Vector2i& image
 
 		switch (depth_type) {
 			default: throw std::runtime_error{"unknown depth type in set_training_image"};
-			case EDepthDataType::UShort: linear_kernel(copy_depth<uint16_t>, 0, nullptr, n_pixels, depth_dst, (const uint16_t*)depth_pixels, depth_scale); break;
+			case EDepthDataType::UShort: linear_kernel(copy_depth<uint16_t>, 0, nullptr, n_pixels, depth_dst, (const uint16_t*)depth_pixels, depth_scale / (1 << 16)); break;
 			case EDepthDataType::Float: linear_kernel(copy_depth<float>, 0, nullptr, n_pixels, depth_dst, (const float*)depth_pixels, depth_scale); break;
 		}
 	} else {

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -227,6 +227,11 @@ PYBIND11_MODULE(pyngp, m) {
 		.value("Volume", ETestbedMode::Volume)
 		.export_values();
 
+	py::enum_<EGroundTruthRenderMode>(m, "GroundTruthRenderMode")
+		.value("Shade", EGroundTruthRenderMode::Shade)
+		.value("Depth", EGroundTruthRenderMode::Depth)
+		.export_values();
+
 	py::enum_<ERenderMode>(m, "RenderMode")
 		.value("AO", ERenderMode::AO)
 		.value("Shade", ERenderMode::Shade)
@@ -422,6 +427,7 @@ PYBIND11_MODULE(pyngp, m) {
 		.def_readwrite("shall_train_encoding", &Testbed::m_train_encoding)
 		.def_readwrite("shall_train_network", &Testbed::m_train_network)
 		.def_readwrite("render_groundtruth", &Testbed::m_render_ground_truth)
+		.def_readwrite("groundtruth_render_mode", &Testbed::m_ground_truth_render_mode)
 		.def_readwrite("render_mode", &Testbed::m_render_mode)
 		.def_readwrite("slice_plane_z", &Testbed::m_slice_plane_z)
 		.def_readwrite("dof", &Testbed::m_dof)

--- a/src/render_buffer.cu
+++ b/src/render_buffer.cu
@@ -433,6 +433,55 @@ __device__ Array3f colormap_viridis(float x) {
 	return (c0+x*(c1+x*(c2+x*(c3+x*(c4+x*(c5+x*c6))))));
 }
 
+__global__ void overlay_depth_kernel(
+	Vector2i resolution,
+	float alpha,
+	const float* __restrict__ depth,
+	float depth_scale,
+	Vector2i image_resolution,
+	int fov_axis,
+	float zoom, Eigen::Vector2f screen_center,
+	cudaSurfaceObject_t surface
+) {
+	uint32_t x = threadIdx.x + blockDim.x * blockIdx.x;
+	uint32_t y = threadIdx.y + blockDim.y * blockIdx.y;
+
+	if (x >= resolution.x() || y >= resolution.y()) {
+		return;
+	}
+
+	float scale = image_resolution[fov_axis] / float(resolution[fov_axis]);
+
+	float fx = x+0.5f;
+	float fy = y+0.5f;
+
+	fx-=resolution.x()*0.5f; fx/=zoom; fx+=screen_center.x() * resolution.x();
+	fy-=resolution.y()*0.5f; fy/=zoom; fy+=screen_center.y() * resolution.y();
+
+	float u = (fx-resolution.x()*0.5f) * scale  + image_resolution.x()*0.5f;
+	float v = (fy-resolution.y()*0.5f) * scale  + image_resolution.y()*0.5f;
+
+	int srcx = floorf(u);
+	int srcy = floorf(v);
+	uint32_t idx = x + resolution.x() * y;
+	uint32_t srcidx = srcx + image_resolution.x() * srcy;
+
+    Array4f color;
+	if (srcx >= image_resolution.x() || srcy >= image_resolution.y() || srcx < 0 || srcy < 0) {
+        color = {0.0f, 0.0f, 0.0f, 0.0f};
+	} else {
+        float depth_value = depth[srcidx] * depth_scale;
+        Array3f c = colormap_turbo(depth_value);
+        color = {c[0], c[1], c[2], 1.0f};
+	}
+
+
+	Array4f prev_color;
+	surf2Dread((float4*)&prev_color, surface, x * sizeof(float4), y);
+	color = color * alpha + prev_color * (1.f-alpha);
+	surf2Dwrite(to_float4(color), surface, x * sizeof(float4), y);
+}
+
 __global__ void overlay_false_color_kernel(Vector2i resolution, Vector2i training_resolution, bool to_srgb, int fov_axis, cudaSurfaceObject_t surface, const float *error_map, Vector2i error_map_resolution, const float *average, float brightness, bool viridis) {
 	uint32_t x = threadIdx.x + blockDim.x * blockIdx.x;
 	uint32_t y = threadIdx.y + blockDim.y * blockIdx.y;
@@ -624,6 +673,32 @@ void CudaRenderBuffer::overlay_image(
 		m_tonemap_curve,
 		m_color_space,
 		output_color_space,
+		fov_axis,
+		zoom,
+		screen_center,
+		surface()
+	);
+}
+
+void CudaRenderBuffer::overlay_depth(
+	float alpha,
+	const float* __restrict__ depth,
+	float depth_scale,
+	const Vector2i& image_resolution,
+	int fov_axis,
+	float zoom,
+	const Eigen::Vector2f& screen_center,
+	cudaStream_t stream
+) {
+	auto res = out_resolution();
+	const dim3 threads = { 16, 8, 1 };
+	const dim3 blocks = { div_round_up((uint32_t)res.x(), threads.x), div_round_up((uint32_t)res.y(), threads.y), 1 };
+	overlay_depth_kernel<<<blocks, threads, 0, stream>>>(
+		res,
+		alpha,
+		depth,
+		depth_scale,
+		image_resolution,
 		fov_axis,
 		zoom,
 		screen_center,

--- a/src/render_buffer.cu
+++ b/src/render_buffer.cu
@@ -459,7 +459,9 @@ __global__ void overlay_depth_kernel(
 	float depth_scale,
 	Vector2i image_resolution,
 	int fov_axis,
-	float zoom, Eigen::Vector2f screen_center,
+	float zoom,
+	float max_depth,
+	Eigen::Vector2f screen_center,
 	cudaSurfaceObject_t surface
 ) {
 	uint32_t x = threadIdx.x + blockDim.x * blockIdx.x;
@@ -489,7 +491,7 @@ __global__ void overlay_depth_kernel(
 	if (srcx >= image_resolution.x() || srcy >= image_resolution.y() || srcx < 0 || srcy < 0) {
         color = {0.0f, 0.0f, 0.0f, 0.0f};
 	} else {
-        float depth_value = depth[srcidx] * depth_scale;
+        float depth_value = depth[srcidx] * depth_scale / max_depth;
         Array3f c = colormap_turbo(depth_value);
         color = {c[0], c[1], c[2], 1.0f};
 	}
@@ -706,6 +708,7 @@ void CudaRenderBuffer::overlay_depth(
 	const Vector2i& image_resolution,
 	int fov_axis,
 	float zoom,
+    float max_depth,
 	const Eigen::Vector2f& screen_center,
 	cudaStream_t stream
 ) {
@@ -720,6 +723,7 @@ void CudaRenderBuffer::overlay_depth(
 		image_resolution,
 		fov_axis,
 		zoom,
+		max_depth,
 		screen_center,
 		surface()
 	);

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -594,6 +594,9 @@ void Testbed::imgui() {
 			accum_reset |= ImGui::SliderInt("training image latent code for inference", (int*)&m_nerf.extra_dim_idx_for_inference, 0, m_nerf.training.dataset.n_images-1);
 		}
 		accum_reset |= ImGui::Combo("Render mode", (int*)&m_render_mode, RenderModeStr);
+		if (m_testbed_mode == ETestbedMode::Nerf)  {
+			accum_reset |= ImGui::Combo("Groundtruth Render mode", (int*)&m_ground_truth_render_mode, GroundTruthRenderModeStr);
+		}
 		accum_reset |= ImGui::Combo("Color space", (int*)&m_color_space, ColorSpaceStr);
 		accum_reset |= ImGui::Combo("Tonemap curve", (int*)&m_tonemap_curve, TonemapCurveStr);
 		accum_reset |= ImGui::ColorEdit4("Background", &m_background_color[0]);
@@ -2659,19 +2662,33 @@ void Testbed::render_frame(const Matrix<float, 3, 4>& camera_matrix0, const Matr
 		if (m_render_ground_truth) {
 			float alpha=1.f;
 			auto const& metadata = m_nerf.training.dataset.metadata[m_nerf.training.view];
-			render_buffer.overlay_image(
-				alpha,
-				Array3f::Constant(m_exposure) + m_nerf.training.cam_exposure[m_nerf.training.view].variable(),
-				m_background_color,
-				to_srgb ? EColorSpace::SRGB : EColorSpace::Linear,
-				metadata.pixels,
-				metadata.image_data_type,
-				metadata.resolution,
-				m_fov_axis,
-				m_zoom,
-				Vector2f::Constant(0.5f),
-				m_inference_stream
-			);
+			if(m_ground_truth_render_mode == EGroundTruthRenderMode::Shade) {
+				render_buffer.overlay_image(
+					alpha,
+					Array3f::Constant(m_exposure) + m_nerf.training.cam_exposure[m_nerf.training.view].variable(),
+					m_background_color,
+					to_srgb ? EColorSpace::SRGB : EColorSpace::Linear,
+					metadata.pixels,
+					metadata.image_data_type,
+					metadata.resolution,
+					m_fov_axis,
+					m_zoom,
+					Vector2f::Constant(0.5f),
+					m_inference_stream
+				);
+			}
+			else if(m_ground_truth_render_mode == EGroundTruthRenderMode::Depth && metadata.depth) {
+                render_buffer.overlay_depth(
+                    alpha,
+                    metadata.depth,
+					1.0f/m_nerf.training.dataset.scale,
+                    metadata.resolution,
+                    m_fov_axis,
+                    m_zoom,
+					Vector2f::Constant(0.5f),
+                    m_inference_stream
+                ); 
+			}
 		}
 
 		// Visualize the accumulated error map if requested

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -813,6 +813,8 @@ void Testbed::imgui() {
 					ImGui::PlotLines("Training view exposures", exposures.data(), exposures.size(), 0, nullptr, FLT_MAX, FLT_MAX, ImVec2(0, 60.f));
 				}
 
+				accum_reset |= ImGui::SliderFloat("Depth Threshold", &m_max_depth, 0.1f, 16.f);
+
 				if (ImGui::SliderInt("glow mode", &m_nerf.glow_mode, 0, 16)) {
 					accum_reset = true;
 				}
@@ -2767,6 +2769,7 @@ void Testbed::render_frame(const Matrix<float, 3, 4>& camera_matrix0, const Matr
 					metadata.resolution,
 					m_fov_axis,
 					m_zoom,
+					m_max_depth,
 					Vector2f::Constant(0.5f),
 					m_stream.get()
 				);
@@ -2779,6 +2782,7 @@ void Testbed::render_frame(const Matrix<float, 3, 4>& camera_matrix0, const Matr
                     metadata.resolution,
                     m_fov_axis,
                     m_zoom,
+					m_max_depth,
 					Vector2f::Constant(0.5f),
                     m_stream.get()
                 ); 

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -2769,7 +2769,6 @@ void Testbed::render_frame(const Matrix<float, 3, 4>& camera_matrix0, const Matr
 					metadata.resolution,
 					m_fov_axis,
 					m_zoom,
-					m_max_depth,
 					Vector2f::Constant(0.5f),
 					m_stream.get()
 				);

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -582,6 +582,7 @@ void Testbed::imgui() {
 		}
 
 		ImGui::Checkbox("Dynamic resolution", &m_dynamic_res);
+		ImGui::Checkbox("Render Groundtruth", &m_render_ground_truth);
 		ImGui::SliderFloat("Target FPS", &m_dynamic_res_target_fps, 2.0f, 144.0f, "%.01f", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoRoundToFormat);
 		ImGui::SliderInt("Max spp", &m_max_spp, 0, 1024, "%d", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoRoundToFormat);
 


### PR DESCRIPTION
# Ticket
https://checkandvisit.atlassian.net/browse/CORE3DML-1092

# Description
Remap 16bits input depth in floating [0; 1]
- 8 bits image like grayscale is automatically remap to 16 bits (*256)

Import Groundtruth Renderer
Add Clipping value to display Groundtruth Depth 

![Screenshot from 2022-07-28 15-06-58](https://user-images.githubusercontent.com/47992681/181514235-01e65dde-98e2-48e7-86aa-da92771ede01.png)

